### PR TITLE
Implement required AudioStreamPlayback virtuals

### DIFF
--- a/demo/tests/playback_lifecycle.gd
+++ b/demo/tests/playback_lifecycle.gd
@@ -1,0 +1,52 @@
+extends SceneTree
+## Regression test for the AudioStreamPlayback lifecycle contract
+## (_stop / _is_playing / _get_playback_position).
+##
+## Run headless from the demo folder:
+##   godot --headless --path . --script tests/playback_lifecycle.gd
+##
+## Exits with the number of failed checks (0 = success).
+
+var failures := 0
+
+
+func check(cond: bool, what: String) -> void:
+	if cond:
+		print("ok - ", what)
+	else:
+		failures += 1
+		printerr("FAIL - ", what)
+
+
+func _initialize() -> void:
+	var player := AudioStreamPlayer.new()
+	player.stream = AudioStreamPD.new()
+	root.add_child(player)
+	for i in 3:
+		await physics_frame
+
+	player.play()
+	for i in 12:
+		await physics_frame
+
+	check(player.has_stream_playback(), "playback exists after play()")
+	check(player.playing, "player.playing is true while audio is active")
+	var playback := player.get_stream_playback() as AudioStreamPlaybackPD
+	check(playback != null, "playback is an AudioStreamPlaybackPD")
+	var position := player.get_playback_position()
+	check(position > 0.0, "playback position advances (%f)" % position)
+
+	player.stop()
+	for i in 3:
+		await physics_frame
+	check(not player.playing, "player.playing is false after stop()")
+
+	player.play()
+	for i in 3:
+		await physics_frame
+	check(player.get_stream_playback() != playback,
+			"play() after stop() creates a new playback (patches must be re-opened)")
+	player.stop()
+
+	print("done: %d failure(s)" % failures)
+	quit(failures)

--- a/demo/tests/playback_lifecycle.gd.uid
+++ b/demo/tests/playback_lifecycle.gd.uid
@@ -1,0 +1,1 @@
+uid://bpwa548rm5xvk

--- a/doc_classes/AudioStreamPlaybackPD.xml
+++ b/doc_classes/AudioStreamPlaybackPD.xml
@@ -7,6 +7,7 @@
 		[AudioStreamPlaybackPD] is your main handle for interacting with Pure Data (Pd). It is meant to be used with [AudioStreamPD].
 		[b]Note[/b]: Before being able to receive messages coming from Pd through signals ([signal receive_bang], [signal receive_float], etc), you have to [method subscribe] to some message sources first.
 		[b]Note[/b]: See the description of [AudioStreamPD] for information on valid value ranges for MIDI messages.
+		[b]Note[/b]: Stopping a player and playing it again creates a [b]new[/b] playback with a fresh Pure Data instance: no patches are open, and all Pd state (arrays, subscriptions, receivers) is gone. After every [method AudioStreamPlayer.play], fetch the new playback with [method AudioStreamPlayer.get_stream_playback], re-open your patches, and re-subscribe.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/src/audio_stream_pd.cpp
+++ b/src/audio_stream_pd.cpp
@@ -1,6 +1,7 @@
 #include "audio_stream_pd.h"
 #include "util.hpp"
 #include <algorithm>
+#include <cstring>
 #include <filesystem>
 #include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/core/class_db.hpp>
@@ -102,6 +103,7 @@ pd::List AudioStreamPlaybackPD::_pd_list_from(const Array &p_arr) {
 
 AudioStreamPlaybackPD::AudioStreamPlaybackPD() {
 	active = false;
+	mixed_frames = 0;
 	stream = nullptr;
 	receiver.set_signaller(this);
 	pd.setReceiver(&receiver);
@@ -128,13 +130,26 @@ int32_t AudioStreamPlaybackPD::_mix_resampled(AudioFrame *p_dst_buffer, int32_t 
 	pd.receiveMessages();
 	pd.receiveMidi();
 
-	int ticks = p_frame_count / libpd_blocksize();
-
 	// an array of `AudioFrame`s is laid out in memory as
 	// interleaved float samples: [left0, right0, left1, right1, left2, right2, ...]
 	// which is exactly what pd.processFloat requires
 	float *dst = reinterpret_cast<float*>(p_dst_buffer);
-	ERR_FAIL_COND_V_MSG(!pd.processFloat(ticks, NULL, dst), p_frame_count, "Pure Data audio processing failed");
+
+	// Pd can only produce whole blocks (64 frames); the engine's resampler
+	// always requests a multiple of that, so ticks == 0 should not happen
+	int ticks = p_frame_count / libpd_blocksize();
+	if (ticks == 0) {
+		memset(dst, 0, sizeof(AudioFrame) * p_frame_count);
+		return p_frame_count;
+	}
+
+	if (!pd.processFloat(ticks, NULL, dst)) {
+		memset(dst, 0, sizeof(AudioFrame) * p_frame_count);
+		active = false;
+		ERR_FAIL_V_MSG(p_frame_count, "Pure Data audio processing failed");
+	}
+
+	mixed_frames += ticks * libpd_blocksize();
 
 	return ticks * libpd_blocksize();
 }
@@ -150,10 +165,29 @@ void AudioStreamPlaybackPD::_start(double p_from_pos) {
 
 	ERR_FAIL_COND_MSG(!pd.init(0, 2, stream->get_mix_rate(), true), "Pure Data could not be initialized.");
 
+	mixed_frames = 0;
 	active = true;
 
 	pd.computeAudio(true);
 	begin_resample();
+}
+
+void AudioStreamPlaybackPD::_stop() {
+	active = false;
+
+	if (pd.isInited()) {
+		pd.computeAudio(false);
+	}
+}
+
+bool AudioStreamPlaybackPD::_is_playing() const {
+	return active;
+}
+
+double AudioStreamPlaybackPD::_get_playback_position() const {
+	ERR_FAIL_COND_V_MSG(stream == nullptr, 0.0, "No audio stream available. Cannot get playback position.");
+
+	return double(mixed_frames.load()) / double(stream->get_mix_rate());
 }
 
 int AudioStreamPlaybackPD::open_patch(String p_path) {

--- a/src/audio_stream_pd.h
+++ b/src/audio_stream_pd.h
@@ -3,6 +3,7 @@
 
 #include "gdpd_receiver.h"
 #include <PdBase.hpp>
+#include <atomic>
 #include <godot_cpp/classes/audio_stream.hpp>
 #include <godot_cpp/classes/audio_stream_playback_resampled.hpp>
 #include <godot_cpp/variant/array.hpp>
@@ -35,7 +36,11 @@ class AudioStreamPlaybackPD : public AudioStreamPlaybackResampled {
 	gdpd::Receiver receiver;
 	pd::PdBase pd;
 	std::vector<pd::Patch> patches;
-	bool active;
+	// written on the main thread, read by the audio thread in _mix_resampled
+	std::atomic<bool> active;
+	// frames produced at the stream rate; written on the audio thread, read
+	// by _get_playback_position on the main thread
+	std::atomic<uint64_t> mixed_frames;
 
 protected:
 	static void _bind_methods();
@@ -45,6 +50,9 @@ public:
 	int32_t _mix_resampled(AudioFrame *p_dst_buffer, int32_t p_frame_count) override;
 	float _get_stream_sampling_rate() const override;
 	void _start(double p_from_pos) override;
+	void _stop() override;
+	bool _is_playing() const override;
+	double _get_playback_position() const override;
 	int open_patch(String p_path);
 	void close_patch(String p_path);
 	void close_patch_id(int p_dollar_zero);


### PR DESCRIPTION
Hi @fediazc 👋,

Thanks for putting together this project. It's been very helpful!

I have a bunch of changes that I'd like to incorporate that I've implemented while building out a game that entirely uses Pd for generative audio. This is the biggest (and most important of them) so I figured I'd start with this.

Claude did all the implementation work under my direction here, but I am not familiar at all with the godot c++ nor libpd APIs so please feel free to push back on anything if it doesn't make sense.

This was discovered when I wanted to stop and free the pd resources when a player leaves an area that has a Pd generated stream: _stop, _is_playing, and _get_playback_position are marked REQUIRED by the engine (servers/audio/audio_stream.h) but were not overridden.

Consequences in production:

- get_playback_position() printed a required-virtual error and returned 0
- stop() printed two required-virtual errors and never reached the playback — the `p_playback->stop()` call inside `AudioServer::stop_playback_stream` is a no-op without `_stop` — so Pd DSP shutdown only happened when the last Ref dropped
- every `is_playing()` query against the playback errored and returned false; the engine makes these itself (`stop_playback_stream`, used-stream tagging), and any script that fetches the playback gets the same wrong answer plus the error spam

(Correction from an earlier version of this description: I originally wrote that `player.playing` itself read false while audio played. That was a misdiagnosis on my side — the player property reads the AudioServer's registration state, not the playback virtual, on both 4.3 and 4.7, so it was never affected. The broken surface is the playback-side contract above, not the player property.)

This implements them:

_stop() deactivates the mixer callback and turns Pd DSP off; _is_playing() reports the active flag; _get_playback_position() derives the position from a frame counter accumulated at the stream rate in _mix_resampled. `active` and the new counter are atomics — they cross the main/audio thread boundary.

Also hardened _mix_resampled: a processFloat failure now zero-fills the buffer and deactivates the playback instead of returning an uninitialized buffer as if it were audio, and a request smaller than one Pd block (cannot happen with the engine's resampler today) returns silence instead of ticking Pd with zero blocks.

demo/tests/playback_lifecycle.gd is a headless regression test covering the full contract, including that play() after stop() creates a fresh playback (documented in the class reference: patches and all Pd state must be re-established). Against the 0.2.0 release binaries the position check fails and the required-virtual errors print; with this PR the run is clean. Verified against an AudioStreamGenerator control that the one ObjectDB instance reported leaked at hard exit is engine-generic, not specific to this extension.

Thanks!
